### PR TITLE
Fix couple of trivial cases for TOP schemas

### DIFF
--- a/jsonsubschema/_canonicalization.py
+++ b/jsonsubschema/_canonicalization.py
@@ -4,8 +4,6 @@ Created on June 24, 2019
 '''
 
 import copy
-import jsonschema
-import numbers
 import numpy
 import sys
 

--- a/jsonsubschema/_canonicalization.py
+++ b/jsonsubschema/_canonicalization.py
@@ -127,7 +127,11 @@ def canonicalize_single_type(d):
 
 
 def canonicalize_list_of_types(d):
-    t = sorted(d.get("type"))
+    t = set(d.get("type"))
+    if t == definitions.JallTypes and \
+        not set(d.keys()).intersection(definitions.JtypesRestrictionKeywords):
+        return JSONtop()
+    
     anyofs = []
     for t_i in t:
         if t_i in definitions.Jtypes:

--- a/jsonsubschema/_checkers.py
+++ b/jsonsubschema/_checkers.py
@@ -1340,6 +1340,9 @@ class JSONTypeObject(JSONschema):
             extra_keys_on_rhs = set(s2.properties.keys()).difference(
                 s1.properties.keys())
             for k in extra_keys_on_rhs.copy():
+                if all(map(is_top, get_schema_for_key(k, s2))):
+                    extra_keys_on_rhs.remove(k)
+                    continue
                 for k_ in s1.patternProperties.keys():
                     if utils.regex_matches_string(k_, k):
                         extra_keys_on_rhs.remove(k)

--- a/jsonsubschema/_constants.py
+++ b/jsonsubschema/_constants.py
@@ -11,6 +11,8 @@ Jnumeric = set(["integer", "number"])
 
 Jtypes = Jnumeric.union(["string", "boolean", "null", "array", "object"])
 
+JallTypes = Jnumeric.union(Jtypes)
+
 JtypesToKeywords = {
     "string": ["minLength", "maxLength", "pattern"],
     "number": ["minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"],
@@ -21,14 +23,16 @@ JtypesToKeywords = {
     "object": ["properties", "additionalProperties", "required", "minProperties", "maxProperties", "dependencies", "patternProperties"]
 }
 
+JtypesRestrictionKeywords = reduce(operator.add, JtypesToKeywords.values())
+
 Jconnectors = set(["anyOf", "allOf", "oneOf", "not"])
 
 Jcommonkw = Jconnectors.union(["enum", "type"])
 
 JNonValidation = set(["$schema", "$id", "definitions", "title", "description", "format"])
 
-Jkeywords = Jcommonkw.union(Jtypes,
-                            reduce(operator.add, JtypesToKeywords.values())).union(["$ref"])
+# Jkeywords = Jcommonkw.union(Jtypes, reduce(operator.add, JtypesToKeywords.values())).union(["$ref"])
+Jkeywords = Jcommonkw.union(Jtypes, JtypesRestrictionKeywords, ["$ref"])
                             # .union(JNonValidation) # conflicts with canonicalize_connectors
 
 JtypesToPyTypes = {"integer": int, "number": float, "string": str,

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -504,7 +504,6 @@ class TestObjectSubtype(unittest.TestCase):
         with self.subTest():
             self.assertFalse(isSubschema(s2, s1))
 
-
     def test_real_object_schema(self):
         s1 = {'additionalProperties': False,
               'properties': {'X': {'$schema': 'http://json-schema.org/draft-04/schema#',
@@ -550,6 +549,33 @@ class TestObjectSubtype(unittest.TestCase):
             self.assertTrue(isSubschema(s1, s2))
         with self.subTest():
             self.assertFalse(isSubschema(s2, s1))
+
+    def test_property_top1(self):
+        s1 = {"type":"object",
+              "properties": {"name":{},
+                             "age": {"type": "integer"}}}
+        s2 = {"type":"object",
+              "properties": {"age": {"type": "integer"}}}
+        
+        with self.subTest():
+            self.assertTrue(isSubschema(s1, s2))
+
+        with self.subTest():
+            self.assertTrue(isSubschema(s2, s1))
+
+    def test_property_top2(self):
+        s1 = {"type":"object",
+              "properties": {"name":{"type": ["number","integer", "string", "boolean","object","array", "null"]},
+                             "age": {"type": "integer"}}}
+        s2 = {"type":"object",
+              "properties": {"age": {"type": "integer"},
+                             "name": {}}}
+        
+        with self.subTest():
+            self.assertTrue(isSubschema(s1, s2))
+
+        with self.subTest():
+            self.assertTrue(isSubschema(s2, s1))
 
 class TestDependency(unittest.TestCase):
 


### PR DESCRIPTION
This PR fixes the follow-up issue mentioned in https://github.com/IBM/jsonsubschema/issues/14 by doing the following:

    Adding a canonicalization step for the complete list of types where no other restriction words are used (i.e. an explicit TOP type)
    When checking for the object subtype relation, a property on the RHS is ignored from the subtype check in case it is
        An extra property on the RHS, and
        All its matching schemas are TOP

I have also added a couple of test cases that check for this specific case.