### PR TITLE
Add support for `const`

### DIFF
--- a/jsonsubschema/_canonicalization.py
+++ b/jsonsubschema/_canonicalization.py
@@ -83,6 +83,8 @@ def canonicalize_dict(d, outer_key=None):
         return canonicalize_connectors(d)
     elif "enum" in d.keys():
         return canonicalize_enum(d)
+    elif "const" in d.keys():
+        return canonicalize_const(d)
     elif utils.is_str(t):
         return canonicalize_single_type(d)
     elif utils.is_list(t):
@@ -171,6 +173,9 @@ def canonicalize_enum(d):
         d["type"] = actual_t
     return canonicalize_list_of_types(d)
 
+def canonicalize_const(d):
+    d["enum"] = [d.pop("const")]
+    return canonicalize_enum(d)
 
 def canonicalize_connectors(d):
     connectors = definitions.Jconnectors.intersection(d.keys())

--- a/jsonsubschema/_checkers.py
+++ b/jsonsubschema/_checkers.py
@@ -48,9 +48,6 @@ class JSONschema(dict, metaclass=UninhabitedMeta):
         # do it here once and fir all.
         if "enum" in self:
             self.enum = self["enum"]
-        # const is just an enum with a single value
-        elif "const" in self:
-            self.enum = [self["const"]]
 
     def updateInternalState(self):
         pass

--- a/jsonsubschema/_checkers.py
+++ b/jsonsubschema/_checkers.py
@@ -48,6 +48,9 @@ class JSONschema(dict, metaclass=UninhabitedMeta):
         # do it here once and fir all.
         if "enum" in self:
             self.enum = self["enum"]
+        # const is just an enum with a single value
+        elif "const" in self:
+            self.enum = [self["const"]]
 
     def updateInternalState(self):
         pass

--- a/jsonsubschema/_constants.py
+++ b/jsonsubschema/_constants.py
@@ -27,7 +27,7 @@ JtypesRestrictionKeywords = reduce(operator.add, JtypesToKeywords.values())
 
 Jconnectors = set(["anyOf", "allOf", "oneOf", "not"])
 
-Jcommonkw = Jconnectors.union(["enum", "type"])
+Jcommonkw = Jconnectors.union(["enum", "type", "const"])
 
 JNonValidation = set(["$schema", "$id", "definitions", "title", "description", "format"])
 

--- a/test/test_const.py
+++ b/test/test_const.py
@@ -1,0 +1,109 @@
+import unittest
+
+from jsonsubschema import isSubschema
+from jsonsubschema.exceptions import UnsupportedEnumCanonicalization
+
+
+class TestConst(unittest.TestCase):
+    def test_const_equal_num(self) -> None:
+        s1 = {"const": 1}
+        s2 = {"const": 1}
+
+        with self.subTest("LHS < RHS"):
+            assert isSubschema(s1, s2)
+        with self.subTest("LHS > RHS"):
+            assert isSubschema(s2, s1)
+
+    def test_const_equal_str(self) -> None:
+        s1 = {"const": "a"}
+        s2 = {"const": "a"}
+
+        with self.subTest("LHS < RHS"):
+            assert isSubschema(s1, s2)
+        with self.subTest("LHS > RHS"):
+            assert isSubschema(s2, s1)
+
+    def test_const_vs_enum(self) -> None:
+        s1 = {"const": 1}
+        s2 = {"enum": [1, 2]}
+
+        with self.subTest("LHS < RHS"):
+            assert isSubschema(s1, s2)
+        with self.subTest("LHS > RHS"):
+            assert not isSubschema(s2, s1)
+
+    def test_const_vs_wrong_enum(self) -> None:
+        s1 = {"const": 1}
+        s2 = {"enum": [2, 3]}
+
+        with self.subTest("LHS < RHS"):
+            assert not isSubschema(s1, s2)
+        with self.subTest("LHS > RHS"):
+            assert not isSubschema(s2, s1)
+
+    def test_const_vs_type(self) -> None:
+        s1 = {"const": 1}
+        s2 = {"type": "integer"}
+
+        with self.subTest("LHS < RHS"):
+            assert isSubschema(s1, s2)
+        with self.subTest("LHS > RHS"):
+            assert not isSubschema(s2, s1)
+
+    def test_const_vs_wrong_type(self) -> None:
+        s1 = {"const": 1}
+        s2 = {"type": "string"}
+
+        with self.subTest("LHS < RHS"):
+            assert not isSubschema(s1, s2)
+        with self.subTest("LHS > RHS"):
+            assert not isSubschema(s2, s1)
+
+    def test_const_type_mix(self) -> None:
+        s1 = {"const": "1"}
+        s2 = {"const": 1}
+
+        with self.subTest("LHS < RHS"):
+            assert not isSubschema(s1, s2)
+        with self.subTest("LHS > RHS"):
+            assert not isSubschema(s2, s1)
+
+    def test_enum_uninhabited1(self) -> None:
+        s1 = {"type": "string", "const": 1}
+        s2 = {"type": "string"}
+
+        with self.subTest("LHS < RHS"):
+            assert isSubschema(s1, s2)
+        with self.subTest("LHS > RHS"):
+            assert not isSubschema(s2, s1)
+
+    def test_enum_uninhabited2(self) -> None:
+        s1 = {"type": "string", "const": 1}
+        s2 = {"type": "boolean", "const": 1}
+
+        with self.subTest("LHS < RHS"):
+            assert isSubschema(s1, s2)
+        with self.subTest("LHS > RHS"):
+            assert isSubschema(s2, s1)
+
+
+class TestEnumNotSupported(unittest.TestCase):
+    def test_array(self) -> None:
+        s1 = {"const": []}
+        s2 = {"type": "array"}
+
+        with self.subTest():
+            self.assertRaises(UnsupportedEnumCanonicalization, isSubschema, s1, s2)
+
+        with self.subTest():
+            self.assertRaises(UnsupportedEnumCanonicalization, isSubschema, s2, s1)
+
+    def test_object(self) -> None:
+        s1 = {"const": {}}
+        s2 = {"type": "object"}
+
+        with self.subTest():
+            self.assertRaises(UnsupportedEnumCanonicalization, isSubschema, s1, s2)
+
+        with self.subTest():
+            self.assertRaises(UnsupportedEnumCanonicalization, isSubschema, s2, s1)


### PR DESCRIPTION
JSON Schema draft 6 introduces [const](https://json-schema.org/understanding-json-schema/reference/const), which is syntactic sugar for a single-valued enum. This PR adds support for this keyword.