### PR TITLE
Update version of Greenery

### DIFF
--- a/jsonsubschema/_checkers.py
+++ b/jsonsubschema/_checkers.py
@@ -9,7 +9,7 @@ import math
 import sys
 
 import portion as I
-from greenery.lego import parse
+from greenery import parse
 
 import jsonsubschema.config as config
 

--- a/jsonsubschema/_utils.py
+++ b/jsonsubschema/_utils.py
@@ -14,7 +14,7 @@ import json
 
 import jsonschema
 import portion as I
-from greenery.lego import parse
+from greenery import parse
 
 import jsonsubschema.config as config
 import jsonsubschema._constants as definitions

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url='https://github.com/IBM/jsonsubschema',
     packages=['jsonsubschema', ],
     license='Apache License 2.0',
-    install_requires=['portion', 'greenery<=3.3.3', 'jsonschema', 'jsonref'],
+    install_requires=['portion', 'greenery>=4.0.0', 'jsonschema', 'jsonref'],
     entry_points={
         'console_scripts': 'jsonsubschema=jsonsubschema.cli:main'
     }


### PR DESCRIPTION
It seems as though the Greenery can be safely updated past 3.3.3. The package structure has changed a bit, but the use of `lego` seems to be no longer necessary and all tests pass.