### PR TITLE
Fix regex metacharacters in enums

### DIFF
--- a/jsonsubschema/_canonicalization.py
+++ b/jsonsubschema/_canonicalization.py
@@ -7,6 +7,7 @@ import copy
 import jsonschema
 import numbers
 import math
+import re
 import sys
 
 import jsonsubschema._constants as definitions
@@ -272,7 +273,7 @@ def rewrite_enum(d):
     ret = None
 
     if t == "string":
-        pattern = "|".join(map(lambda x: "^"+str(x)+"$", enum))
+        pattern = "|".join(map(lambda x: "^"+str(re.escape(x))+"$", enum))
         ret = {"type": "string", "pattern": pattern}
 
     if t == "integer":

--- a/test/test_enum.py
+++ b/test/test_enum.py
@@ -85,6 +85,15 @@ class TestEnum(unittest.TestCase):
         with self.subTest('LHS > RHS'):
             self.assertTrue(isSubschema(s2, s1))
 
+    def test_enum_regex_string(self):
+        s1 = {'enum': ['^*']}
+        s2 = {'enum': ['^^']}
+
+        with self.subTest('LHS < RHS'):
+            self.assertFalse(isSubschema(s1, s2))
+        with self.subTest('LHS > RHS'):
+            self.assertFalse(isSubschema(s2, s1))
+
 
 class TestEnumNotSupported(unittest.TestCase):
 


### PR DESCRIPTION
When string enums contains regular expression meta characters such as `^` they are not properly escaped, which can cause canonicalization to produce incorrect results.
This fix may not be perfect since Python does not use ECMA 262 syntax for regular expressions as in JSON Schema.
