### PR TITLE
Fix join of enum with string

### DIFF
--- a/jsonsubschema/_checkers.py
+++ b/jsonsubschema/_checkers.py
@@ -359,10 +359,6 @@ class JSONTypeString(JSONschema):
                 if s1_new_pattern and s2_new_pattern:
                     ret["pattern"] = "^" + s1_new_pattern + \
                         "$|^" + s2_new_pattern + "$"
-                elif s1_new_pattern:
-                    ret["pattern"] = "^" + s1_new_pattern + "$"
-                elif s2_new_pattern:
-                    ret["pattern"] = "^" + s2_new_pattern + "$"
                 return JSONTypeString(ret)
             else:
                 return JSONanyOf({"anyOf": [s1, s2]})

--- a/jsonsubschema/_utils.py
+++ b/jsonsubschema/_utils.py
@@ -199,7 +199,7 @@ def regex_isSubset(s1, s2):
     elif s1:
         return True
     elif s2:
-        return False
+        return parse(s2).equivalent(parse(".*"))
 
 
 # def regex_isProperSubset(s1, s2):

--- a/test/test_string.py
+++ b/test/test_string.py
@@ -212,6 +212,11 @@ class TestStringEnumSubtype(unittest.TestCase):
         with self.subTest():
             self.assertFalse(isSubschema(s2, s1))
 
+    def test_enum4(self):
+        s1 = {"anyOf": [{"enum": ["a", "b", "c"]}, {"type": "string"}]}
+        s2 = {"type": "string"}
+        self.assertTrue(isEquivalent(s1, s2))
+
     def test_not_enum1(self):
         s1 = {"type": "string", "not": {"enum": ["a"]}}
         s2 = {"type": "string"}


### PR DESCRIPTION
The join of a string restricted by a pattern with an unrestricted string is the unrestricted string, because it contains every possible string.